### PR TITLE
fix: add existing correction data to edits so as to not get deleted

### DIFF
--- a/VSCOKeys.lrdevplugin/Client.lua
+++ b/VSCOKeys.lrdevplugin/Client.lua
@@ -248,6 +248,16 @@ function Client:loop()
 
           if (table.count(edits) > 0) then
             photo.catalog:withWriteAccessDo("VSCO Keys", function()
+
+              -- In LRC 9.3, these properties below get overwritten when applying any plugin edit preset. 
+              -- As a fix, we're copying them from the existing image settings
+              -- and setting them back onto the image as part of the edit preset
+              -- This feels like a bug on the SDK, as this doesn't happen to any other property.
+              -- Raised here: https://community.adobe.com/t5/lightroom-classic/all-corrections-get-overwritten-when-calling-applydeveloppreset-with-a-plugin-preset-in-lrc-9-3/m-p/11245013?page=1#M191778
+              edits.PaintBasedCorrections = photoData.PaintBasedCorrections
+              edits.CircularGradientBasedCorrections = photoData.CircularGradientBasedCorrections
+              edits.GradientBasedCorrections = photoData.GradientBasedCorrections
+
               local preset = LrApplication.addDevelopPresetForPlugin(_PLUGIN, editText, edits)
               photo:applyDevelopPreset(preset, _PLUGIN)
 


### PR DESCRIPTION
Seems like in LRC 9.3, some changes were made to the SDK that resets 'Corrections', when plugin presets are applied.

This feels more like a bug in the SDK than an expected behaviour, as the other values do not get modified when they are not set.

Raised in the Adobe forums here: https://community.adobe.com/t5/lightroom-classic/all-corrections-get-overwritten-when-calling-applydeveloppreset-with-a-plugin-preset-in-lrc-9-3/m-p/11245013?page=1#M191778

For the time being here's a fix that copies all 'Corrections' on an image (Brush, radial and graduated filters), and reapplies them on the edit.

Closes #3 